### PR TITLE
Update reamde with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
-# address deduplicator
+# Pelias address deduplicator
 A stream that performs address deduplication using the robust
 [OpenVenues deduplicator](https://github.com/openvenues/address_deduper); note that it must be separately installed and
 running.
+
+## 🚨 Notice: This package is deprecated
+
+*Over time, the query-time deduplication features of [pelias/api](https://github.com/pelias/api)
+have been improved to the point where this package is no longer needed.*
+
+*While functional, the address deduplicator is quite difficult to run reliably. It often fails during
+long imports, and even in the best cases dramatically reduces import speed.*
+
+*It would take considerable work to improve this project to the point where it would be recommended
+for general use with Pelias again, and we believe most deduplication problems can be solved in
+importers or in the API.*
+
+*If anyone has a particular need for this deduplicator and would like to maintain it, please reach
+out by opening an issue in [pelias/pelias](https://github.com/pelias/pelias/)*
+
 
 ## API
 `pelias-address-deduplicator` exports a single function:


### PR DESCRIPTION
For some time now we have effectively treated the address deduplicator
as deprecated. It technically works but in practice is hard to use
effectively, and query-time deduplication in the API has gotten much
better and is more flexible.

I'd like to eventually archive this Github repositry, and possibly even
mark the NPM packages for the address deduplicator as deprecated. This
update is at least a start of that.

Connects https://github.com/pelias/pelias/issues/702